### PR TITLE
Added the sleep functionality for the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # DailyQuotes
 Get daily quotes on TFT screen, controlled by an IL9341 controller, connected to an ESP8266
 
+Description:
+	The system displays at every 24 hours a new quote. After this, it goes to sleep to save as much power as possible. 
+	It wakes up at aproximately 3 hours and 25 minutes ( the max time to sleep for ESP8266 ) and go to sleep again until the 24 hours have been reached. This is detected by decrementing a variable stored in the RTC memory which is not erased when the ESP8266 wakes up from sleep.
 Components:
 1. ESP8266 (preferable and NodeMCU or any other development board, for easy connections )
 2. Any dispaly with IL9341 controller ( mine is a 2.8inch TFT_LCD 240*320 RGB screen )
@@ -13,3 +16,6 @@ Credits:
 4. Quotes API from: https://theysaidso.com/api/
 5. TFT libraries: https://github.com/adafruit/Adafruit_ILI9341
 				  https://github.com/adafruit/Adafruit-GFX-Library
+6. RTC memory guidance: https://www.esp8266.com/viewtopic.php?p=20009
+						https://github.com/esp8266/esp8266-wiki/wiki/Memory-Map
+						https://github.com/SensorsIot/ESP8266-RTC-Memory/blob/master/RTCmemTest/RTCmemTest.ino


### PR DESCRIPTION
The mean current use dropped at half (from 118mA used by the hole system, to 44mA when the system is sleeping. It sleeps for 23 hours and 58 minutes ( so 44mA on this time ) and is awake for 2 minutes a day ( 118mA on this time ).

Also, changed the used pins to increase the stability of the system, when is powered from the programmer. ( CP2102 USB-TTL board )